### PR TITLE
实现延迟注册服务到 Nacos

### DIFF
--- a/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationAutoConfiguration.java
+++ b/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationAutoConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2023 Macula
+ *   macula.dev, China
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.macula.boot.starter.cloud.alibaba.config;
 
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
@@ -9,6 +26,8 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * 延迟注册服务到 Nacos 配置
+ *
+ * @author Gordian
  */
 @Configuration
 @ConditionalOnBean({NacosServiceRegistry.class, Registration.class})

--- a/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationAutoConfiguration.java
+++ b/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationAutoConfiguration.java
@@ -1,0 +1,25 @@
+package dev.macula.boot.starter.cloud.alibaba.config;
+
+import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 延迟注册服务到 Nacos 配置
+ */
+@Configuration
+@ConditionalOnBean({NacosServiceRegistry.class, Registration.class})
+@ConditionalOnProperty(prefix = "spring.cloud.nacos.discovery", name = "register-enabled", havingValue = "false")
+public class NacosDelayRegistrationAutoConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.cloud.nacos.discovery", name = "register-delayed", havingValue = "true")
+    public NacosDelayRegistrationListener nacosDelayRegistrationListener(
+            NacosServiceRegistry nacosServiceRegistry, Registration registration) {
+        return new NacosDelayRegistrationListener(nacosServiceRegistry, registration);
+    }
+
+}

--- a/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationListener.java
+++ b/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationListener.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2023 Macula
+ *   macula.dev, China
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.macula.boot.starter.cloud.alibaba.config;
 
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
@@ -7,6 +24,8 @@ import org.springframework.context.ApplicationListener;
 
 /**
  * 延迟注册服务到 Nacos
+ *
+ * @author Gordian
  */
 public class NacosDelayRegistrationListener implements ApplicationListener<ApplicationReadyEvent> {
 

--- a/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationListener.java
+++ b/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/java/dev/macula/boot/starter/cloud/alibaba/config/NacosDelayRegistrationListener.java
@@ -1,0 +1,26 @@
+package dev.macula.boot.starter.cloud.alibaba.config;
+
+import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * 延迟注册服务到 Nacos
+ */
+public class NacosDelayRegistrationListener implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final NacosServiceRegistry nacosServiceRegistry;
+    private final Registration registration;
+
+    public NacosDelayRegistrationListener(NacosServiceRegistry nacosServiceRegistry, Registration registration) {
+        this.nacosServiceRegistry = nacosServiceRegistry;
+        this.registration = registration;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        nacosServiceRegistry.register(registration);
+    }
+
+}

--- a/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/macula-boot-starters/macula-boot-starter-cloud/macula-boot-starter-cloud-alibaba/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.macula.boot.starter.cloud.alibaba.config.NacosDelayRegistrationAutoConfiguration


### PR DESCRIPTION
当 spring.cloud.nacos.discovery.register-enabled=false 且 spring.cloud.nacos.discovery.register-delayed=true 时，延迟注册服务到 Nacos，实现容器优雅上线。

